### PR TITLE
[fix] price에서 1000의 배수가 잘 찍히지 않는 버그 해결

### DIFF
--- a/FruitFruit/FruitFruit/Info.plist
+++ b/FruitFruit/FruitFruit/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>OrderView</string>
+					<string>Home</string>
 				</dict>
 			</array>
 		</dict>

--- a/FruitFruit/FruitFruit/Views/OrderResultStoryboard/OrderSheet.swift
+++ b/FruitFruit/FruitFruit/Views/OrderResultStoryboard/OrderSheet.swift
@@ -153,18 +153,11 @@ extension OrderSheet {
     }
     
     private func setTotalPriceToString(price: Int) -> String {
-        let share: String
-        let remainder: String
         let result: String
+        let numberFormatter = NumberFormatter()
         
-        if price >= 1000 {
-            share = String(price / 1000)
-            remainder = String(price % 1000)
-            result = share + "," + remainder
-        } else {
-            result = String(price)
-        }
-        
+        numberFormatter.numberStyle = .decimal
+        result = numberFormatter.string(from: NSNumber(value: price))!
         return result + "원"
     }
     

--- a/FruitFruit/FruitFruit/Views/OrderResultStoryboard/SheetTable.swift
+++ b/FruitFruit/FruitFruit/Views/OrderResultStoryboard/SheetTable.swift
@@ -14,7 +14,6 @@ class SheetTable: UIView {
         let sheet = SheetRow()
         sheet.translatesAutoresizingMaskIntoConstraints = false
         sheet.label.text = "개수"
-//        sheet.value.text = "3개"
         return sheet
     }()
     
@@ -22,7 +21,6 @@ class SheetTable: UIView {
         let sheet = SheetRow()
         sheet.translatesAutoresizingMaskIntoConstraints = false
         sheet.label.text = "금액"
-//        sheet.value.text = "2,400원"
         return sheet
     }()
     
@@ -30,7 +28,6 @@ class SheetTable: UIView {
         let sheet = SheetRow()
         sheet.translatesAutoresizingMaskIntoConstraints = false
         sheet.label.text = "수령장소"
-//        sheet.value.text = "포스텍 C5"
         return sheet
     }()
     
@@ -38,7 +35,6 @@ class SheetTable: UIView {
         let sheet = SheetRow()
         sheet.translatesAutoresizingMaskIntoConstraints = false
         sheet.label.text = "시간"
-//        sheet.value.text = "오후 1시"
         return sheet
     }()
     


### PR DESCRIPTION
1000의 배수를 기준으로 쉼표를 추가하는 로직을 잘못 설계해서 오류가 발생했습니다.
기존에는 간단한 If else 문으로 코드를 짰는데 버그가 있어서 NumberFormatter 라는 함수를 사용해서 
자동으로 쉼표가 생길 수 있도록 수정했습니다.